### PR TITLE
postsをpublishedだけに絞る

### DIFF
--- a/lib/notion.js
+++ b/lib/notion.js
@@ -7,6 +7,14 @@ const notion = new Client({
 export const getDatabase = async (databaseId) => {
   const response = await notion.databases.query({
     database_id: databaseId,
+    filter: {
+      or: [
+        {
+          property: 'Published',
+          'status': { equals: 'Done'}
+        }
+       ]
+    }
   });
   return response.results;
 };


### PR DESCRIPTION
## 実装内容

- notionのデータベース のpostsは publishedのモノだけを公開する

※参考
https://developers.notion.com/reference/post-database-query